### PR TITLE
add lt escape

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -16,6 +16,7 @@ module.exports = function (data) {
   if (!ignore(data)) {
     data.content = data.content
       .replace(reg, function (raw, start, startQuote, lang, content, endQuote, end) {
+        content = content.replace(/</g, '&lt;');
         return `${start}<pre class="mermaid">${content}</pre>${end}`;
       });
   }


### PR DESCRIPTION
if there is < in content when using classDiagram, it will not work. For example 
```mermaind
classDiagram
      Animal <|-- Duck
      Animal <|-- Fish
```
so we must add < escape, it will work.
```mermaind
 classDiagram
      Animal &lt|-- Duck
      Animal &lt|-- Zebra
```